### PR TITLE
add timeout & number of tries for wget

### DIFF
--- a/scripts/2_download_from_urls.sh
+++ b/scripts/2_download_from_urls.sh
@@ -19,5 +19,5 @@ do
 	mkdir -p "$images_dir"
 	echo "Class: $cname. Total # of urls: $(cat $urls_file | wc -l)"
 	echo "Downloading images..."
-	wget -nc -q -i "$urls_file" -P "$images_dir"
+	wget -nc -q -i --timeout=20 --tries=2 "$urls_file" -P "$images_dir"
 done


### PR DESCRIPTION
I had issue that some urls block wget from downloading images faster, because default values of `wget` for timeout and number of tries are too big it will stack too long on urls that have some connection issues.