### PR TITLE
Download images in parallel

### DIFF
--- a/scripts/2_download_from_urls.sh
+++ b/scripts/2_download_from_urls.sh
@@ -19,5 +19,5 @@ do
 	mkdir -p "$images_dir"
 	echo "Class: $cname. Total # of urls: $(cat $urls_file | wc -l)"
 	echo "Downloading images..."
-	wget -nc -q --timeout=5 --tries=2 -i "$urls_file" -P "$images_dir"
+	xargs -n 20 -P 8 wget -nc -q --timeout=5 --tries=2 -P "$images_dir" < "$urls_file"
 done


### PR DESCRIPTION
We can use `xargs` and `wget` together to download images faster. Some people propose to use GNU `parallel` to make it even better, but the problem that `parallel` is not installed everywhere as default package. Idea was took from here https://stackoverflow.com/questions/7577615/parallel-wget-in-bash as was suggested by @alexkimxyz . Here some stats on downloading 1000 images:
```
wget -nc -q --timeout=5 --tries=2 -i "$urls_file" -P "$images_dir"
1 min 2 sec

xargs -n 20 -P 8 wget -nc -q --timeout=5 --tries=2 -P "$images_dir" < "$urls_file"
0 min 42 sec

xargs -n 1 -P 8 wget -nc -q --timeout=5 --tries=2 -P "$images_dir" < "$urls_file"
0 min 42 sec
```
First method is not parallelised (current implementation), other two have parallelisation only difference between them in `-n` flag, it was suggested to use value ~20 for better usage.

> When downloading multiple files over HTTP, wget can reuse the HTTP connection thanks to the Keep-Alive mechanic. When you launch a new process per each file, this mechanism cannot be used and the connection (TCP triple way handshake) has to be established again and again. So I suggest bumping up the -n parameter to about 20 or so. In default configuration Apache HTTP server will serve only up to 100 requests in one kept-alive session, so there is probably no point in going over a hundered here.  

Even if I can't see any difference in time I propose to leave it with value of 20.