### PR TITLE
fix a uuidgen command not find error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 RUN apt update \
  && apt upgrade -y \
- && apt install wget rsync imagemagick default-jre -y 
+ && apt install wget rsync imagemagick default-jre uuid-runtime -y 
 RUN mkdir /root/nsfw_data_scraper
 WORKDIR /root/nsfw_data_scraper
 COPY ./ /root/nsfw_data_scraper

--- a/scripts/1_get_urls_.sh
+++ b/scripts/1_get_urls_.sh
@@ -15,7 +15,6 @@ declare -a class_names=(
 for cname in "${class_names[@]}"
 do
 	echo "Getting images for class: $cname"
-	urls_file="$raw_data_dir/$cname/urls_$cname.txt"
 	while read url
 	do
 		if [[ ! "$url" =~ ^"#" ]]


### PR DESCRIPTION
1. uuidgen command not exists in ubuntu-18.04
2. remote unused code `urls_file="$raw_data_dir/$cname/urls_$cname.txt"`