### PR TITLE
Preventing duplicates by using sha256 hash as filename

### DIFF
--- a/scripts/5_create_train_.sh
+++ b/scripts/5_create_train_.sh
@@ -26,7 +26,7 @@ do
 		find "$raw_data_class_dir" -type f \( -name '*.jpg' -o -name '*.jpeg' \) -print0 |
 		while IFS= read -r -d '' jpg_f
 		do
-		    cp "$jpg_f" "$train_dir/$cname/$(uuidgen).jpg"
+		    cp "$jpg_f" "$train_dir/$cname/$(sha256sum $jpg_f | awk '{print $1}').jpg"
 		done
 	fi
 done


### PR DESCRIPTION
By using sha256 hash as a filename instead of uuidgen we can make sure that every file is unique since it can happen that two different subreddits share the exact same image and it will be twice in the training set