### PR TITLE
Fix Caltech256 links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here is what each script (located under `scripts` directory) does:
 *Note*: I already ran this script for you, and its outputs are located in `raw_data` directory. No need to rerun unless you edit files under `scripts/source_urls`.
 - `2_download_from_urls_.sh` - downloads actual images for urls found in text files in `raw_data` directory.
 - `3_optional_download_drawings_.sh` - (optional) script that downloads SFW anime images from the [Danbooru2018](https://www.gwern.net/Danbooru2018) database.
-- `4_optional_download_neutral_.sh` - (optional) script that downloads SFW neutral images from the [Caltech256](http://www.vision.caltech.edu/Image_Datasets/Caltech256/) dataset
+- `4_optional_download_neutral_.sh` - (optional) script that downloads SFW neutral images from the [Caltech256](https://data.caltech.edu/records/nyy15-4j048) dataset
 - `5_create_train_.sh` - creates `data/train` directory and copy all `*.jpg` and `*.jpeg` files into it from `raw_data`. Also removes corrupted images.
 - `6_create_test_.sh` - creates `data/test` directory and moves `N=2000` random files for each class from `data/train` to `data/test` (change this number inside the script if you need a different train/test split). Alternatively, you can run it multiple times, each time it will move `N` images for each class from `data/train` to `data/test`.
 

--- a/scripts/4_optional_download_neutral_.sh
+++ b/scripts/4_optional_download_neutral_.sh
@@ -5,5 +5,5 @@ base_dir="$(dirname "$scripts_dir")"
 raw_data_dir="$base_dir/raw_data"
 mkdir -p "$raw_data_dir/neutral"
 
-wget http://www.vision.caltech.edu/Image_Datasets/Caltech256/256_ObjectCategories.tar -P "$raw_data_dir/neutral"
+wget https://data.caltech.edu/records/nyy15-4j048/files/256_ObjectCategories.tar -P "$raw_data_dir/neutral"
 tar -xf "$raw_data_dir/neutral/256_ObjectCategories.tar" -C "$raw_data_dir/neutral"


### PR DESCRIPTION
Direct mentioning @alex000kim for review.

This PR fixes any references of Caltech256 to point towards a more current link at [data.caltech.org](https://data.caltech.edu/records/nyy15-4j048) since the previous link is dead.

I also took a look at the Danbooru series of datasets and it seems like they have moved it to a different rsync server. From what I found, it seems that the Danbooru2018 dataset that was previously used can be subsetted *out* of the current dataset by ignoring all images after ID #3,368,713. I haven't made any changes to [3_optional_download_drawings_.sh](https://github.com/alex000kim/nsfw_data_scraper/blob/main/scripts/3_optional_download_drawings_.sh) since I'm not one to decide whether to switch to Danbooru2021. 